### PR TITLE
GPL-3.0 -> GPL-3.0-only

### DIFF
--- a/maubot.yaml
+++ b/maubot.yaml
@@ -2,7 +2,7 @@
 maubot: 0.1.0
 id: test.irregularchat.matrix_to_discourse
 version: 0.1.1.1
-license: GPL-3.0
+license: GPL-3.0-only
 modules:
   - bot
 main_class: MatrixToDiscourseBot

--- a/plugin/maubot.yaml
+++ b/plugin/maubot.yaml
@@ -2,7 +2,7 @@
 maubot: 0.1.0
 id: blacklisted.irregularchat.matrix_to_discourse
 version: 1.2.1
-license: GPL-3.0
+license: GPL-3.0-only
 modules:
   - MatrixToDiscourseBot
 main_class: MatrixToDiscourseBot


### PR DESCRIPTION
GPL-3.0 is a deprecated SPDX license identifier, GPL-3.0-only and GPL-3.0-or-later are the proper identifiers. Since your plugin is advertised as GPL-3.0-only on plugins.maubot.xyz, that's what I used here.